### PR TITLE
Display in-development stage plugins

### DIFF
--- a/docs/plugins/docker/overview.md
+++ b/docs/plugins/docker/overview.md
@@ -1,0 +1,13 @@
+# Docker
+
+__Repository__: <https://github.com/xrally/xrally-docker>
+
+!!! note
+
+    This package is under active development and has not been released yet.
+
+    Follow the repository on GitHub to do not miss any updates.
+
+## Description
+
+A set of xRally plugins to run workloads against Docker platform.

--- a/docs/plugins/kubernetes/overview.md
+++ b/docs/plugins/kubernetes/overview.md
@@ -1,0 +1,13 @@
+# Kubernetes
+
+__Repository__: <https://github.com/xrally/xrally-kubernetes>
+
+!!! note
+
+    This package is under active development and has not been released yet.
+
+    Follow the repository on GitHub to do not miss any updates.
+
+## Description
+
+A set of xRally plugins to run workloads against Kubernetes platform.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,8 @@ pages:
   - In-tree:
     - {Plugins: plugins/in_tree/plugins.md}
     - {Config Options: plugins/in_tree/options.md}
+  - {Docker: plugins/docker/overview.md}
+  - {Kubernetes: plugins/kubernetes/overview.md}
   - OpenStack:
     - {Overview: plugins/openstack/overview.md}
     - {Plugins: plugins/openstack/plugins.md}

--- a/plugins.json
+++ b/plugins.json
@@ -11,5 +11,17 @@
          "repository": "https://github.com/openstack/rally-openstack",
          "versions": ["1.0.0", "1.1.0"],
          "changelog_file": "CHANGELOG.rst"
+    },
+    {
+         "name": "xrally-docker",
+         "title": "Docker",
+         "repository": "https://github.com/xrally/xrally-docker",
+         "description": "A set of xRally plugins to run workloads against Docker platform."
+    },
+    {
+         "name": "xrally-kuberneted",
+         "title": "Kubernetes",
+         "repository": "https://github.com/xrally/xrally-kubernetes",
+         "description": "A set of xRally plugins to run workloads against Kubernetes platform."
     }
 ]

--- a/xrally_docs_tools/plugins_ref/pages.py
+++ b/xrally_docs_tools/plugins_ref/pages.py
@@ -80,6 +80,26 @@ class OverviewPage(PackagePage):
         return "\n\n".join(page)
 
 
+class DevOverviewPage(PackagePage):
+    """Shows the overview page for a package which had not been released yet"""
+    NAME = "overview.md"
+
+    def _make(self):
+        page = [
+            "# %s" % self.package["title"],
+            "__Repository__: <%s>" % self.package["repository"],
+            "!!! note",
+            "    This package is under active development and has not "
+            "been released yet.",
+            "    Follow the repository on GitHub to do not miss any updates."
+        ]
+        if "description" in self.package:
+            page.append("## Description")
+            page.append(self.package["description"])
+
+        return "\n\n".join(page)
+
+
 class ChangeLogPage(PackagePage):
     """Shows changelog for the package."""
 


### PR DESCRIPTION
It is would be nice to display "in active development" packages under
plugins reference page. It can help to involve more contributors and
inform the xRally consumers about news.

This patch extends `tox -e update_plugins` script to generate pages for
such packages.
Also, xrally-docker and xrally-kubernetes packages are added.