### PR TITLE
Fix getting default values fo cli arguments

### DIFF
--- a/docs/ref/cli.md
+++ b/docs/ref/cli.md
@@ -79,8 +79,6 @@ Check availability of all platforms in environment.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: env</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -147,8 +145,6 @@ d-description"> [ref]</a>
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: description</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -164,8 +160,6 @@ e-extras"> [ref]</a>
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: extras</span>
         <br>
       </td>
     </tr>
@@ -191,8 +185,6 @@ s-path"> [ref]</a>
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: spec</span>
         <br>
       </td>
     </tr>
@@ -242,8 +234,6 @@ Deletes all records related to Env from db.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: env</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -282,8 +272,6 @@ Destroy existing environment.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: env</span>
         <br>
       </td>
     </tr>
@@ -341,8 +329,6 @@ Show environment information.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: env</span>
         <br>
       </td>
     </tr>
@@ -407,8 +393,6 @@ List existing environments.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: env</span>
         <br>
       </td>
     </tr>
@@ -501,8 +485,6 @@ List all Rally plugins that match name and platform.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: name</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -517,8 +499,6 @@ List all Rally plugins that match name and platform.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: platform</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -530,8 +510,6 @@ List all Rally plugins that match name and platform.
         <br>
         <span>
 </span>
-        <br>
-        <span><i>Defaults</i>: platform</span>
         <br>
       </td>
     </tr>
@@ -546,8 +524,6 @@ List all Rally plugins that match name and platform.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: base_cls</span>
         <br>
       </td>
     </tr>
@@ -593,8 +569,6 @@ Show detailed information about a Rally plugin.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: platform</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -606,8 +580,6 @@ Show detailed information about a Rally plugin.
         <br>
         <span>
 </span>
-        <br>
-        <span><i>Defaults</i>: platform</span>
         <br>
       </td>
     </tr>
@@ -762,8 +734,6 @@ Export task results to the custom task's exporting system.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: tasks</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -778,8 +748,6 @@ Export task results to the custom task's exporting system.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: output_type</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -793,8 +761,6 @@ Export task results to the custom task's exporting system.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: output_dest</span>
         <br>
       </td>
     </tr>
@@ -826,8 +792,6 @@ Import json results of a test into rally database
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: task_file</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -855,8 +819,6 @@ Import json results of a test into rally database
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: tags</span>
         <br>
       </td>
     </tr>
@@ -915,8 +877,6 @@ deployment without filtering by status.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: status</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -930,8 +890,6 @@ deployment without filtering by status.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: tags</span>
         <br>
       </td>
     </tr>
@@ -970,8 +928,6 @@ Generate a report for the specified task(s).
         <span>
 </span>
         <br>
-        <span><i>Defaults</i>: tasks</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -985,8 +941,6 @@ Generate a report for the specified task(s).
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: out</span>
         <br>
       </td>
     </tr>
@@ -1046,8 +1000,6 @@ Generate a report for the specified task(s).
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: tasks</span>
         <br>
       </td>
     </tr>
@@ -1218,8 +1170,6 @@ filename-path"> [ref]</a>
         <span>
 </span>
         <br>
-        <span><i>Defaults</i>: task_args</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -1231,8 +1181,6 @@ filename-path"> [ref]</a>
         <br>
         <span>
 </span>
-        <br>
-        <span><i>Defaults</i>: task_args_file</span>
         <br>
       </td>
     </tr>
@@ -1247,8 +1195,6 @@ filename-path"> [ref]</a>
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: tags</span>
         <br>
       </td>
     </tr>
@@ -1450,8 +1396,6 @@ filename-path"> [ref]</a>
         <span>
 </span>
         <br>
-        <span><i>Defaults</i>: task_args</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -1463,8 +1407,6 @@ filename-path"> [ref]</a>
         <br>
         <span>
 </span>
-        <br>
-        <span><i>Defaults</i>: task_args_file</span>
         <br>
       </td>
     </tr>
@@ -1500,8 +1442,6 @@ Add a verifier extension.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: verifier_id</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -1515,8 +1455,6 @@ Add a verifier extension.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: source</span>
         <br>
       </td>
     </tr>
@@ -1532,8 +1470,6 @@ Add a verifier extension.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: version</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -1547,8 +1483,6 @@ Add a verifier extension.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: extra</span>
         <br>
       </td>
     </tr>
@@ -1579,8 +1513,6 @@ Configure a verifier for a specific deployment.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: verifier_id</span>
         <br>
       </td>
     </tr>
@@ -1619,8 +1551,6 @@ Configure a verifier for a specific deployment.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: extra_options</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -1634,8 +1564,6 @@ Configure a verifier for a specific deployment.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: new_configuration</span>
         <br>
       </td>
     </tr>
@@ -1704,8 +1632,6 @@ Create a verifier.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: platform</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -1717,8 +1643,6 @@ Create a verifier.
         <br>
         <span>
 </span>
-        <br>
-        <span><i>Defaults</i>: platform</span>
         <br>
       </td>
     </tr>
@@ -1734,8 +1658,6 @@ Create a verifier.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: source</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -1749,8 +1671,6 @@ Create a verifier.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: version</span>
         <br>
       </td>
     </tr>
@@ -1774,8 +1694,6 @@ Create a verifier.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: extra</span>
         <br>
       </td>
     </tr>
@@ -1899,8 +1817,6 @@ Delete a verifier extension.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: verifier_id</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -1914,8 +1830,6 @@ Delete a verifier extension.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: name</span>
         <br>
       </td>
     </tr>
@@ -1947,8 +1861,6 @@ Import results of a test run into the Rally database.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: verifier_id</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -1977,8 +1889,6 @@ Import results of a test run into the Rally database.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: file_to_parse</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -1992,8 +1902,6 @@ Import results of a test run into the Rally database.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: run_args</span>
         <br>
       </td>
     </tr>
@@ -2034,8 +1942,6 @@ List all verifications.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: verifier_id</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -2064,8 +1970,6 @@ List all verifications.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: tags</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -2079,8 +1983,6 @@ List all verifications.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: status</span>
         <br>
       </td>
     </tr>
@@ -2112,8 +2014,6 @@ List all plugins for verifiers management.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: platform</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -2125,8 +2025,6 @@ List all plugins for verifiers management.
         <br>
         <span>
 </span>
-        <br>
-        <span><i>Defaults</i>: platform</span>
         <br>
       </td>
     </tr>
@@ -2158,8 +2056,6 @@ List all verifier extensions.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: verifier_id</span>
-        <br>
       </td>
     </tr>
   </tbody>
@@ -2190,8 +2086,6 @@ List all verifier tests.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: verifier_id</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -2205,8 +2099,6 @@ List all verifier tests.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: pattern</span>
         <br>
       </td>
     </tr>
@@ -2238,8 +2130,6 @@ List all verifiers.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: status</span>
-        <br>
       </td>
     </tr>
   </tbody>
@@ -2270,8 +2160,6 @@ Generate a report for a verification or a few verifications.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: verification_uuid</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -2286,8 +2174,6 @@ Generate a report for a verification or a few verifications.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: output_type</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -2301,8 +2187,6 @@ Generate a report for a verification or a few verifications.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: output_dest</span>
         <br>
       </td>
     </tr>
@@ -2343,8 +2227,6 @@ Rerun tests from a verification for a specific deployment.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: verification_uuid</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -2382,8 +2264,6 @@ Rerun tests from a verification for a specific deployment.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: tags</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -2397,8 +2277,6 @@ Rerun tests from a verification for a specific deployment.
 </span>
         <br>
         <span><i>Type</i>: int</span>
-        <br>
-        <span><i>Defaults</i>: concur</span>
         <br>
       </td>
     </tr>
@@ -2448,8 +2326,6 @@ Show detailed information about a verification.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: verification_uuid</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -2464,7 +2340,7 @@ Show detailed information about a verification.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: sort_by</span>
+        <span><i>Defaults</i>: name</span>
         <br>
       </td>
     </tr>
@@ -2505,8 +2381,6 @@ Show detailed information about a verifier.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: verifier_id</span>
-        <br>
       </td>
     </tr>
   </tbody>
@@ -2537,8 +2411,6 @@ Start a verification (run verifier tests).
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: verifier_id</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -2567,8 +2439,6 @@ Start a verification (run verifier tests).
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: tags</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -2582,8 +2452,6 @@ Start a verification (run verifier tests).
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: pattern</span>
         <br>
       </td>
     </tr>
@@ -2599,8 +2467,6 @@ Start a verification (run verifier tests).
         <br>
         <span><i>Type</i>: int</span>
         <br>
-        <span><i>Defaults</i>: concur</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -2614,8 +2480,6 @@ Start a verification (run verifier tests).
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: load_list</span>
         <br>
       </td>
     </tr>
@@ -2631,8 +2495,6 @@ Start a verification (run verifier tests).
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: skip_list</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -2646,8 +2508,6 @@ Start a verification (run verifier tests).
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: xfail_list</span>
         <br>
       </td>
     </tr>
@@ -2697,8 +2557,6 @@ Update a verifier.
         <br>
         <span><i>Type</i>: str</span>
         <br>
-        <span><i>Defaults</i>: verifier_id</span>
-        <br>
       </td>
     </tr>
     <tr>
@@ -2721,8 +2579,6 @@ Update a verifier.
 </span>
         <br>
         <span><i>Type</i>: str</span>
-        <br>
-        <span><i>Defaults</i>: version</span>
         <br>
       </td>
     </tr>

--- a/xrally_docs_tools/sources/cli.json
+++ b/xrally_docs_tools/sources/cli.json
@@ -57,14 +57,13 @@
                 {
                     "arguments": [
                         {
-                            "description": "UUID or name of the env.", 
                             "dest": "env", 
                             "args": [
                                 "--env"
                             ], 
-                            "defaults": "env", 
                             "type": "str", 
-                            "metavar": "<uuid>"
+                            "metavar": "<uuid>", 
+                            "description": "UUID or name of the env."
                         }, 
                         {
                             "dest": "to_json", 
@@ -106,7 +105,7 @@
                                 "--description", 
                                 "-d"
                             ], 
-                            "defaults": "description", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<description>"
                         }, 
@@ -117,7 +116,7 @@
                                 "--extras", 
                                 "-e"
                             ], 
-                            "defaults": "extras", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<extras>"
                         }, 
@@ -136,7 +135,7 @@
                                 "--spec", 
                                 "-s"
                             ], 
-                            "defaults": "spec", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<path>"
                         }, 
@@ -164,14 +163,13 @@
                 {
                     "arguments": [
                         {
-                            "description": "UUID or name of the env.", 
                             "dest": "env", 
                             "args": [
                                 "--env"
                             ], 
-                            "defaults": "env", 
                             "type": "str", 
-                            "metavar": "<uuid>"
+                            "metavar": "<uuid>", 
+                            "description": "UUID or name of the env."
                         }, 
                         {
                             "dest": "force", 
@@ -189,14 +187,13 @@
                 {
                     "arguments": [
                         {
-                            "description": "UUID or name of the env.", 
                             "dest": "env", 
                             "args": [
                                 "--env"
                             ], 
-                            "defaults": "env", 
                             "type": "str", 
-                            "metavar": "<uuid>"
+                            "metavar": "<uuid>", 
+                            "description": "UUID or name of the env."
                         }, 
                         {
                             "dest": "skip_cleanup", 
@@ -230,14 +227,13 @@
                 {
                     "arguments": [
                         {
-                            "description": "UUID or name of the env.", 
                             "dest": "env", 
                             "args": [
                                 "--env"
                             ], 
-                            "defaults": "env", 
                             "type": "str", 
-                            "metavar": "<uuid>"
+                            "metavar": "<uuid>", 
+                            "description": "UUID or name of the env."
                         }, 
                         {
                             "dest": "to_json", 
@@ -270,14 +266,13 @@
                 {
                     "arguments": [
                         {
-                            "description": "UUID or name of the env.", 
                             "dest": "env", 
                             "args": [
                                 "--env"
                             ], 
-                            "defaults": "env", 
                             "type": "str", 
-                            "metavar": "<uuid>"
+                            "metavar": "<uuid>", 
+                            "description": "UUID or name of the env."
                         }, 
                         {
                             "dest": "to_json", 
@@ -338,7 +333,7 @@
                             "args": [
                                 "--name"
                             ], 
-                            "defaults": "name", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<name>"
                         }, 
@@ -348,7 +343,7 @@
                             "args": [
                                 "--platform"
                             ], 
-                            "defaults": "platform", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<platform>"
                         }, 
@@ -358,7 +353,7 @@
                                 "--namespace"
                             ], 
                             "metavar": null, 
-                            "defaults": "platform", 
+                            "defaults": null, 
                             "description": "[Deprecated since Rally 0.10.0] Use '--platform' instead. "
                         }, 
                         {
@@ -367,7 +362,7 @@
                             "args": [
                                 "--plugin-base"
                             ], 
-                            "defaults": "base_cls", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<plugin_base>"
                         }
@@ -393,7 +388,7 @@
                             "args": [
                                 "--platform"
                             ], 
-                            "defaults": "platform", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<platform>"
                         }, 
@@ -403,7 +398,7 @@
                                 "--namespace"
                             ], 
                             "metavar": null, 
-                            "defaults": "platform", 
+                            "defaults": null, 
                             "description": "[Deprecated since Rally 0.10.0] Use '--platform' instead. "
                         }
                     ], 
@@ -497,7 +492,7 @@
                             "args": [
                                 "--uuid"
                             ], 
-                            "defaults": "tasks", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<uuid>"
                         }, 
@@ -507,7 +502,7 @@
                             "args": [
                                 "--type"
                             ], 
-                            "defaults": "output_type", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<type>"
                         }, 
@@ -517,7 +512,7 @@
                             "args": [
                                 "--to"
                             ], 
-                            "defaults": "output_dest", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<dest>"
                         }
@@ -534,7 +529,7 @@
                             "args": [
                                 "--file"
                             ], 
-                            "defaults": "task_file", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<path>"
                         }, 
@@ -553,7 +548,7 @@
                             "args": [
                                 "--tag"
                             ], 
-                            "defaults": "tags", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<tag>"
                         }
@@ -587,7 +582,7 @@
                             "args": [
                                 "--status"
                             ], 
-                            "defaults": "status", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<status>"
                         }, 
@@ -597,7 +592,7 @@
                             "args": [
                                 "--tag"
                             ], 
-                            "defaults": "tags", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<tag>"
                         }, 
@@ -622,7 +617,7 @@
                                 "--tasks"
                             ], 
                             "metavar": null, 
-                            "defaults": "tasks", 
+                            "defaults": null, 
                             "description": "[Deprecated since Rally 0.10.0] Use '--uuid' instead. "
                         }, 
                         {
@@ -631,7 +626,7 @@
                             "args": [
                                 "--out"
                             ], 
-                            "defaults": "out", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<path>"
                         }, 
@@ -681,7 +676,7 @@
                             "args": [
                                 "--uuid"
                             ], 
-                            "defaults": "tasks", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<uuid>"
                         }
@@ -780,7 +775,7 @@
                                 "--task-args"
                             ], 
                             "metavar": "<json>", 
-                            "defaults": "task_args", 
+                            "defaults": null, 
                             "description": "Input task args (JSON dict). These args are used to render the Jinja2 template in the input task."
                         }, 
                         {
@@ -789,7 +784,7 @@
                                 "--task-args-file"
                             ], 
                             "metavar": "<path>", 
-                            "defaults": "task_args_file", 
+                            "defaults": null, 
                             "description": "Path to the file with input task args (dict in JSON/YAML). These args are used to render the Jinja2 template in the input task."
                         }, 
                         {
@@ -798,7 +793,7 @@
                             "args": [
                                 "--tag"
                             ], 
-                            "defaults": "tags", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<tag>"
                         }, 
@@ -922,7 +917,7 @@
                                 "--task-args"
                             ], 
                             "metavar": "<json>", 
-                            "defaults": "task_args", 
+                            "defaults": null, 
                             "description": "Input task args (JSON dict). These args are used to render the Jinja2 template in the input task."
                         }, 
                         {
@@ -931,7 +926,7 @@
                                 "--task-args-file"
                             ], 
                             "metavar": "<path>", 
-                            "defaults": "task_args_file", 
+                            "defaults": null, 
                             "description": "Path to the file with input task args (dict in JSON/YAML). These args are used to render the Jinja2 template in the input task."
                         }
                     ], 
@@ -953,7 +948,7 @@
                             "args": [
                                 "--id"
                             ], 
-                            "defaults": "verifier_id", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<id>"
                         }, 
@@ -963,7 +958,7 @@
                             "args": [
                                 "--source"
                             ], 
-                            "defaults": "source", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<source>"
                         }, 
@@ -973,7 +968,7 @@
                             "args": [
                                 "--version"
                             ], 
-                            "defaults": "version", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<version>"
                         }, 
@@ -983,7 +978,7 @@
                             "args": [
                                 "--extra-settings"
                             ], 
-                            "defaults": "extra", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<extra_settings>"
                         }
@@ -1000,7 +995,7 @@
                             "args": [
                                 "--id"
                             ], 
-                            "defaults": "verifier_id", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<id>"
                         }, 
@@ -1027,7 +1022,7 @@
                             "args": [
                                 "--extend"
                             ], 
-                            "defaults": "extra_options", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<path/json/yaml>"
                         }, 
@@ -1037,7 +1032,7 @@
                             "args": [
                                 "--override"
                             ], 
-                            "defaults": "new_configuration", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<path>"
                         }, 
@@ -1080,7 +1075,7 @@
                             "args": [
                                 "--platform"
                             ], 
-                            "defaults": "platform", 
+                            "defaults": "", 
                             "type": "str", 
                             "metavar": "<platform>"
                         }, 
@@ -1090,7 +1085,7 @@
                                 "--namespace"
                             ], 
                             "metavar": null, 
-                            "defaults": "platform", 
+                            "defaults": "", 
                             "description": "[Deprecated since Rally 0.10.0] Use '--platform' instead. "
                         }, 
                         {
@@ -1099,7 +1094,7 @@
                             "args": [
                                 "--source"
                             ], 
-                            "defaults": "source", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<source>"
                         }, 
@@ -1109,7 +1104,7 @@
                             "args": [
                                 "--version"
                             ], 
-                            "defaults": "version", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<version>"
                         }, 
@@ -1127,7 +1122,7 @@
                             "args": [
                                 "--extra-settings"
                             ], 
-                            "defaults": "extra", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<extra_settings>"
                         }, 
@@ -1201,7 +1196,7 @@
                             "args": [
                                 "--id"
                             ], 
-                            "defaults": "verifier_id", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<id>"
                         }, 
@@ -1211,7 +1206,7 @@
                             "args": [
                                 "--name"
                             ], 
-                            "defaults": "name", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<name>"
                         }
@@ -1228,7 +1223,7 @@
                             "args": [
                                 "--id"
                             ], 
-                            "defaults": "verifier_id", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<id>"
                         }, 
@@ -1247,7 +1242,7 @@
                             "args": [
                                 "--file"
                             ], 
-                            "defaults": "file_to_parse", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<path>"
                         }, 
@@ -1257,7 +1252,7 @@
                             "args": [
                                 "--run-args"
                             ], 
-                            "defaults": "run_args", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<run_args>"
                         }, 
@@ -1282,7 +1277,7 @@
                             "args": [
                                 "--id"
                             ], 
-                            "defaults": "verifier_id", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<id>"
                         }, 
@@ -1301,7 +1296,7 @@
                             "args": [
                                 "--tag"
                             ], 
-                            "defaults": "tags", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<tag>"
                         }, 
@@ -1311,7 +1306,7 @@
                             "args": [
                                 "--status"
                             ], 
-                            "defaults": "status", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<status>"
                         }
@@ -1328,7 +1323,7 @@
                             "args": [
                                 "--platform"
                             ], 
-                            "defaults": "platform", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<platform>"
                         }, 
@@ -1338,7 +1333,7 @@
                                 "--namespace"
                             ], 
                             "metavar": null, 
-                            "defaults": "platform", 
+                            "defaults": null, 
                             "description": "[Deprecated since Rally 0.10.0] Use '--platform' instead. "
                         }
                     ], 
@@ -1354,7 +1349,7 @@
                             "args": [
                                 "--id"
                             ], 
-                            "defaults": "verifier_id", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<id>"
                         }
@@ -1371,7 +1366,7 @@
                             "args": [
                                 "--id"
                             ], 
-                            "defaults": "verifier_id", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<id>"
                         }, 
@@ -1381,7 +1376,7 @@
                             "args": [
                                 "--pattern"
                             ], 
-                            "defaults": "pattern", 
+                            "defaults": "", 
                             "type": "str", 
                             "metavar": "<pattern>"
                         }
@@ -1398,7 +1393,7 @@
                             "args": [
                                 "--status"
                             ], 
-                            "defaults": "status", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<status>"
                         }
@@ -1415,7 +1410,7 @@
                             "args": [
                                 "--uuid"
                             ], 
-                            "defaults": "verification_uuid", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<uuid>"
                         }, 
@@ -1425,7 +1420,7 @@
                             "args": [
                                 "--type"
                             ], 
-                            "defaults": "output_type", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<type>"
                         }, 
@@ -1435,7 +1430,7 @@
                             "args": [
                                 "--to"
                             ], 
-                            "defaults": "output_dest", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<dest>"
                         }, 
@@ -1460,7 +1455,7 @@
                             "args": [
                                 "--uuid"
                             ], 
-                            "defaults": "verification_uuid", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<uuid>"
                         }, 
@@ -1487,7 +1482,7 @@
                             "args": [
                                 "--tag"
                             ], 
-                            "defaults": "tags", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<tag>"
                         }, 
@@ -1497,7 +1492,7 @@
                             "args": [
                                 "--concurrency"
                             ], 
-                            "defaults": "concur", 
+                            "defaults": null, 
                             "type": "int", 
                             "metavar": "<N>"
                         }, 
@@ -1530,7 +1525,7 @@
                             "args": [
                                 "--uuid"
                             ], 
-                            "defaults": "verification_uuid", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<uuid>"
                         }, 
@@ -1540,7 +1535,7 @@
                             "args": [
                                 "--sort-by"
                             ], 
-                            "defaults": "sort_by", 
+                            "defaults": "name", 
                             "type": "str", 
                             "metavar": "<query>"
                         }, 
@@ -1565,7 +1560,7 @@
                             "args": [
                                 "--id"
                             ], 
-                            "defaults": "verifier_id", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<id>"
                         }
@@ -1582,7 +1577,7 @@
                             "args": [
                                 "--id"
                             ], 
-                            "defaults": "verifier_id", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<id>"
                         }, 
@@ -1601,7 +1596,7 @@
                             "args": [
                                 "--tag"
                             ], 
-                            "defaults": "tags", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<tag>"
                         }, 
@@ -1611,7 +1606,7 @@
                             "args": [
                                 "--pattern"
                             ], 
-                            "defaults": "pattern", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<pattern>"
                         }, 
@@ -1621,7 +1616,7 @@
                             "args": [
                                 "--concurrency"
                             ], 
-                            "defaults": "concur", 
+                            "defaults": 0, 
                             "type": "int", 
                             "metavar": "<N>"
                         }, 
@@ -1631,7 +1626,7 @@
                             "args": [
                                 "--load-list"
                             ], 
-                            "defaults": "load_list", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<path>"
                         }, 
@@ -1641,7 +1636,7 @@
                             "args": [
                                 "--skip-list"
                             ], 
-                            "defaults": "skip_list", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<path>"
                         }, 
@@ -1651,7 +1646,7 @@
                             "args": [
                                 "--xfail-list"
                             ], 
-                            "defaults": "xfail_list", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<path>"
                         }, 
@@ -1684,7 +1679,7 @@
                             "args": [
                                 "--id"
                             ], 
-                            "defaults": "verifier_id", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<id>"
                         }, 
@@ -1702,7 +1697,7 @@
                             "args": [
                                 "--version"
                             ], 
-                            "defaults": "version", 
+                            "defaults": null, 
                             "type": "str", 
                             "metavar": "<version>"
                         }, 

--- a/xrally_docs_tools/update_cli_reference.py
+++ b/xrally_docs_tools/update_cli_reference.py
@@ -127,10 +127,11 @@ def discover_cli():
                         argument["type"] = arg_type.__name__
 
                     skip_default = argument["dest"] in ("deployment",
+                                                        "env",
                                                         "task_id",
                                                         "verification")
                     if not skip_default and argument["dest"] in defaults:
-                        argument["defaults"] = argument["dest"]
+                        argument["defaults"] = defaults[argument["dest"]]
 
                 arguments.append(argument)
             commands.append({
@@ -171,7 +172,7 @@ def generate_page(categories):
 
                 if "type" in argument:
                     description.append("<i>Type</i>: %s" % argument["type"])
-                if "defaults" in argument:
+                if "defaults" in argument and argument["defaults"]:
                     description.append(
                         "<i>Defaults</i>: %s" % argument["defaults"])
 


### PR DESCRIPTION
While processing CLI arguments the wrong variable was used as a source
for default values of arguments.
Also, we do not need to print default values in case of None value.